### PR TITLE
intro in main, quicksort negative tests, typename > class correction

### DIFF
--- a/SortingMethods/Sorter.h
+++ b/SortingMethods/Sorter.h
@@ -1,5 +1,8 @@
 #pragma once
-template<typename T>
+/*
+* Provides an interface for sorting arrays of type T
+*/
+template<class T>
 class Sorter {
 public:
 

--- a/SortingMethods/SortingMethods.cpp
+++ b/SortingMethods/SortingMethods.cpp
@@ -17,10 +17,11 @@ void printArray(T arr[], size_t size) {
 }
 
 /*
-* main required.
-* 
+main required.
+This only shows Quicksort. To analyze all sorting methods, either:
+  * Test -> Run All Tests
+  * "Ctrl+R, A"
 */
-
 int main() {
     int arr[] = { 10, 7, 8, 9, 1, 5 };
     int n = sizeof(arr) / sizeof(arr[0]);

--- a/SortingMethodsTest/SortingMethodsTest.cpp
+++ b/SortingMethodsTest/SortingMethodsTest.cpp
@@ -22,14 +22,6 @@ namespace SortingMethodsTest
 				Assert::AreEqual(expected[i], actual[i]);
 			}
 		}
-
-		template<class T>
-		void printArray(T arr[], size_t size) {
-			for (size_t i = 0; i < size; i++) {
-				printf("%d", arr[i]);
-				if (i < size - 1) printf(", ");
-			}
-		}
 		#pragma endregion
 
 		#pragma region Positive Tests
@@ -102,6 +94,7 @@ namespace SortingMethodsTest
 		TEST_METHOD(quickSort) {
 			s = new Quicksort<int>();
 			positive_Tests(s);
+			negative_Tests(s);
 		}
 
 		TEST_METHOD(bubbleSort) {


### PR DESCRIPTION
Added a brief introductory comment above the main method in SortingMethods to let the viewer know to check the Test Project. 
Corrected an oversight: Quicksort now runs the singular negative test.
Sorter was templated for typenames and is now templated for classes. 